### PR TITLE
데이터 유출 차트 틀

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,12 @@
     "@fontsource/roboto": "^4.5.8",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.12",
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^13.0.0",
-    "@testing-library/user-event": "^13.2.1",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.13",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "d3-force": "^3.0.0",
+    "d3-scale": "^4.0.2",
+    "d3-scale-chromatic": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "jotai": "^1.9.1",
+    "papaparse": "^5.3.2",
     "react": "^18.2.0",
     "react-countup": "^6.3.2",
     "react-dom": "^18.2.0",
@@ -52,6 +50,18 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^13.0.0",
+    "@testing-library/user-event": "^13.2.1",
+    "@types/d3-force": "^3.0.3",
+    "@types/d3-scale": "^4.0.2",
+    "@types/d3-selection": "^3.0.3",
+    "@types/jest": "^27.0.1",
+    "@types/node": "^16.7.13",
+    "@types/papaparse": "^5.3.5",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@types/d3-scale-chromatic": "^3.0.0",
     "gh-pages": "^4.0.0"
   }
 }

--- a/src/components/LeakedStats.tsx
+++ b/src/components/LeakedStats.tsx
@@ -1,6 +1,231 @@
-import { Paper, Typography } from "@mui/material";
-import useGoogleSheets from "use-google-sheets";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Paper, styled, Typography } from "@mui/material";
+import { select } from "d3-selection";
+import { scaleBand, scaleLinear, scaleOrdinal } from "d3-scale";
+import { forceCollide, forceSimulation, forceX, forceY, SimulationNodeDatum } from "d3-force";
+import { schemeTableau10 } from "d3-scale-chromatic";
+import { parse } from "papaparse";
 import CountUp from "react-countup";
+
+const DATA_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSOCrYS0ebaKSohdzgBTQ60Ndmwi1M6LqXFRkge-nI3GY7DtxIpSQUt8k3Z5EWBGdI3uqk2WCIFnzyx/pub?gid=928498616&single=true&output=csv'
+
+const PADDING = {
+  top: 20,
+  right: 10,
+  bottom: 20,
+  left: 10,
+};
+const COLUMN_WIDTH = 60;
+const LABEL_FONT_SIZE = 12;
+const Y_LABEL_WIDTH = 100;
+
+interface BreachNode extends SimulationNodeDatum {
+  company: string;
+  year: number;
+  cause: string;
+  records: number;
+}
+
+function unique<T>(array: T[]): T[] {
+  return Array.from(new Set(array)).sort();
+}
+
+const Container = styled('div')`
+  overflow-x: scroll;
+`
+
+const Svg = styled('svg')`
+  fill: white;
+  background: white;
+`
+
+const LabelY = styled('text')`
+  font-size: 12px;
+  fill: ${({ theme }) => theme.palette.text.secondary};
+  alignment-baseline: middle;
+`
+
+const LabelX = styled('text')`
+  font-size: 12px;
+  fill: ${({ theme }) => theme.palette.text.secondary};
+  text-anchor: middle;
+`
+
+const GridV = styled('line')`
+  stroke: lightgray;
+  stroke-width: 1px;
+  opacity: 0.5;
+`
+
+const AxisX = styled('line')`
+  stroke: black;
+`
+
+function ClusteredForce({
+  height,
+  data,
+}: {
+  height: number;
+  data: BreachNode[];
+}) {
+  const container = useRef<HTMLDivElement>(null);
+  const svg = useRef(null);
+
+  const { years, causes } = useMemo(() => ({
+    years: unique(data.map(d => d.year)),
+    causes: unique(data.map(d => d.cause)),
+  }), [data]);
+
+  const width = years.length * COLUMN_WIDTH;
+
+  const y = useMemo(() => (
+    scaleBand()
+      .domain(causes)
+      .range([PADDING.top, height - PADDING.bottom])
+  ), [causes, height]);
+
+  const x = useMemo(() => (
+    scaleBand()
+      .domain(years.map(String))
+      .range([PADDING.left + Y_LABEL_WIDTH, width - PADDING.right])
+  ), [years, width]);
+
+  const r = useMemo(() => (
+    scaleLinear()
+      .domain([0, Math.max(...data.map(d => d.records))])
+      .range([10, 30])
+  ), [data]);
+
+  const color = useMemo(() => (
+    scaleOrdinal()
+      .domain(causes)
+      .range(schemeTableau10)
+  ), [causes]);
+
+  const rowHeight = y.bandwidth() / causes.length;
+  const columnWidth = x.bandwidth();
+
+  const force = useMemo(() => forceSimulation<BreachNode>(), []);
+
+  useEffect(() => {
+    if (!svg.current) return;
+
+    select(svg.current)
+      .selectAll('circle')
+      .data(data)
+      .enter()
+      .append('circle')
+      .attr('r', d => r(d.records))
+      .attr('fill', d => color(d.cause) as string);
+
+    force
+      .nodes(data)
+      .force('x', forceX(d => (x(d.year.toString()) || 0) + columnWidth / 2))
+      .force('y', forceY(d => (y(d.cause) || 0) + rowHeight))
+      .force('collide', forceCollide(d => (r(d.records) || 0) + 1))
+      .on('tick', () => {
+        select(svg.current)
+          .selectAll('circle')
+          .data(data)
+          .attr('cx', d => d.x || 0)
+          .attr('cy', d => d.y || 0);
+      })
+      .restart();
+
+    return () => {
+      force.stop();
+    }
+  }, [svg, force, data, x, y, r, color, rowHeight, columnWidth]);
+
+  // TODO : handle resize
+
+  return (
+    <Container ref={container}>
+      <Svg ref={svg} width={`${width}px`} height={`${height}px`}>
+        {causes.map(cause => (
+          <LabelY
+            key={cause}
+            x={PADDING.left}
+            y={(y(cause) || 0) + rowHeight}
+          >
+            {cause}
+          </LabelY>
+        ))}
+        {years.map(year => {
+          const _x = x(year.toString()) || 0;
+          return (
+            <g key={year}>
+              <LabelX
+                x={_x}
+                y={height-PADDING.bottom}
+              >
+                {year}
+              </LabelX>
+              <GridV
+                x1={_x}
+                x2={_x}
+                y1={PADDING.top}
+                y2={height - PADDING.bottom}
+              />
+            </g>
+          )
+        })}
+        <AxisX
+          x1={PADDING.left + Y_LABEL_WIDTH}
+          x2={width - PADDING.right}
+          y1={height - PADDING.bottom - LABEL_FONT_SIZE}
+          y2={height - PADDING.bottom - LABEL_FONT_SIZE}
+        />
+      </Svg>
+    </Container>
+  )
+}
+
+function useBreaches() {
+  const [breaches, setBreaches] = useState<BreachNode[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await fetch(DATA_URL)
+      const csv = await response.text()
+      const { data } = parse(csv)
+      const body = data.slice(3) as string[][]
+      const objects: BreachNode[] = body.map(row => ({
+        company: row[1],
+        year: parseInt(row[3]),
+        cause: row[5] || '알 수 없음',
+        records: parseInt(row[6].replace(/,/g, '')),
+      }));
+
+      setBreaches(objects);
+    }
+    fetchData()
+  }, []);
+
+  return breaches
+}
+
+function Stats() {
+  const breaches = useBreaches();
+
+  if (!breaches) return <div>"loading..."</div>;
+
+  const total = breaches.reduce((acc, cur) => acc + cur.records, 0);
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ pt: 1 }}>
+        <CountUp separator="," end={total} />
+        건
+      </Typography>
+      <ClusteredForce
+        height={500}
+        data={breaches}
+      />
+    </div>
+  );
+}
+
 export default function LeakedStats() {
   return (
     <Paper
@@ -14,28 +239,5 @@ export default function LeakedStats() {
     >
       <Stats />
     </Paper>
-  );
-}
-
-function Stats() {
-  const { data, loading, error } = useGoogleSheets({
-    apiKey: process.env.REACT_APP_GOOGLE_SHEETS_API_KEY,
-    sheetId: process.env.REACT_APP_GOOGLE_SHEETS_PUBLIC_ID,
-    sheetsOptions: [{ id: "연도별 유출건수(피벗)" }],
-  });
-  if (error) return <div>{JSON.stringify(error)}</div>;
-  else if (loading) return <div>"loading..."</div>;
-  const leakedData = data?.at(0)?.data?.at(0) || {};
-  return (
-    <div>
-      <Typography variant="h6">{Object.keys(leakedData).join("")}</Typography>
-      <Typography variant="h4" sx={{ pt: 1 }}>
-        <CountUp
-          separator=","
-          end={parseInt(Object.values(leakedData)[0].replaceAll(",", ""))}
-        />
-        건
-      </Typography>
-    </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,33 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-force@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.3.tgz#76cb20d04ae798afede1ea6e41750763ff5a9c82"
+  integrity sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==
+
+"@types/d3-scale-chromatic@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#103124777e8cdec85b20b51fd3397c682ee1e954"
+  integrity sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.2.tgz#41be241126af4630524ead9cb1008ab2f0f26e69"
+  integrity sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.3.tgz#57be7da68e7d9c9b29efefd8ea5a9ef1171e42ba"
+  integrity sha512-Mw5cf6nlW1MlefpD9zrshZ+DAWL4IQ5LnWfRheW6xwsdaWOb6IRRu2H7XPAQcyXEx1D7XQWgdoKR83ui1/HlEA==
+
+"@types/d3-time@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -2213,6 +2240,13 @@
   version "16.18.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.3.tgz#d7f7ba828ad9e540270f01ce00d391c54e6e0abc"
   integrity sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==
+
+"@types/papaparse@^5.3.5":
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.5.tgz#e5ad94b1fe98e2a8ea0b03284b83d2cb252bbf39"
+  integrity sha512-R1icl/hrJPFRpuYj9PVG03WBAlghJj4JW9Py5QdR8FFSxaLmZRyu7xYDCCBZIJNfUv3MYaeBbhBoX958mUTAaw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -3729,6 +3763,92 @@ csstype@^3.0.2, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.0.tgz#15bf96cd9b7333e02eb8de8053d78962eafcff14"
+  integrity sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+"d3-dispatch@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+d3-force@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+"d3-quadtree@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-scale-chromatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.0.0.tgz#65972cb98ae2d4954ef5c932e8704061335d4975"
+  integrity sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -5311,6 +5431,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -6878,6 +7003,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+papaparse@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.2.tgz#d1abed498a0ee299f103130a6109720404fbd467"
+  integrity sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==
 
 param-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
- 간단히 차트의 틀을 잡아두었습니다. 이후 라벨이나 호버 시 팝업을 추가하시면 될 듯 합니다.
- 현재 원의 면적이 유출 양과 같은 비율이 아닙니다. 안에 들어갈 내용에 따라 기본 크기를 변경하면 좋겠습니다.
- 데이터는 sheet API를 사용하지 않고 published csv를 사용했습니다. 현재 구조는 API키가 클라이언트에 노출되는 듯 보입니다.
- Y축을 유출 원인으로 잡았습니다. 필요시 변경하시면 될 듯 합니다.
- 일단 하나의 파일에 모두 몰아 넣었습니다. 규칙이 있다면 분리하면 좋겠습니다.

<img width="931" alt="Screenshot 2022-11-26 at 4 27 01 PM" src="https://user-images.githubusercontent.com/721157/204077492-ae55a143-9e19-4789-b101-d92a8fdb587b.png">
